### PR TITLE
Set stylechecker to compile phase

### DIFF
--- a/SbtParentPlugin.scala
+++ b/SbtParentPlugin.scala
@@ -1,4 +1,4 @@
-import org.scalastyle.sbt.ScalastylePlugin.autoImport.{scalastyleFailOnWarning, scalastyleConfigUrl}
+import org.scalastyle.sbt.ScalastylePlugin.autoImport.{scalastyle, scalastyleFailOnWarning, scalastyleConfigUrl}
 import sbt._
 import sbt.Keys._
 
@@ -15,7 +15,7 @@ object SbtParentPlugin extends AutoPlugin {
         Some("Mainstreethub Releases" at mshRepo + "releases")
     },
     resolvers += "Mainstreethub Releases" at mshRepo + "releases",
-    scalastyleFailOnWarning := true,
-    scalastyleConfigUrl := Some(url("https://raw.githubusercontent.com/mainstreethub/sbt-parent-plugin/master/scalastyle-config.xml"))
+    scalastyleFailOnWarning in Compile := true,
+    scalastyleConfigUrl in Compile := Some(url("https://raw.githubusercontent.com/mainstreethub/sbt-parent-plugin/master/scalastyle-config.xml"))
   )
 }

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 lazy val root = (project in file("."))
   .settings(
     sbtPlugin := true,
-    version := "0.0.1",
+    version := "0.0.6",
     name := "sbt-parent-plugin",
     organization := "com.mainstreethub",
     scalaVersion := "2.10.4",


### PR DESCRIPTION
Scalastyle plugin doesn't follow best practices and isn't an autoPlugin, so config url is being overwritten by the default plugin settings when set in a plugin.